### PR TITLE
I think this will fix the friends leaderboard

### DIFF
--- a/src/main/java/com/example/restservice/LeaderboardService.java
+++ b/src/main/java/com/example/restservice/LeaderboardService.java
@@ -120,7 +120,10 @@ public class LeaderboardService {
                 userOpt.ifPresent(friendUsers::add);
             }
             
-            // Sort
+            Optional<User> currentUserOpt = userService.findById(userId);
+            currentUserOpt.ifPresent(friendUsers::add);
+            System.out.println(friendUsers);
+            
             return friendUsers.stream()
                     .sorted(Comparator.comparingLong(User::getPoints).reversed())
                     .limit(count)


### PR DESCRIPTION
Simple fix, but this should make it so that the friend's leaderboard will include the user if they are top 5 among their friends (same as global leaderboard now)